### PR TITLE
cross-compile / embedded platform support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,11 +28,8 @@ YACC=@YACC@
 #	
 # What to build and install
 #
-lib_LTLIBRARIES = libcandbc.la libcanasc.la libcanvsb.la \
+lib_LTLIBRARIES = libcandbc.la libcanasc.la libcanmdf.la libcanvsb.la \
 	          libcanclg.la libcanblf.la
-if MATLAB
-lib_LTLIBRARIES += libcanmdf.la
-endif
 
 bin_PROGRAMS	= dbccopy dbcls
 if MATLAB

--- a/Makefile.am
+++ b/Makefile.am
@@ -130,7 +130,8 @@ include_HEADERS= src/libcandbc/dbcmodel.h \
 		 src/cantomat/messagedecoder.h \
 		 src/libcanmdf/mdfcn.h \
 		 src/libcanmdf/mdfswap.h \
-		 src/libcanmdf/mdftypes.h
+		 src/libcanmdf/mdftypes.h \
+		 cantools_config.h
 
 libcandbc_la_SOURCES= \
 	src/libcandbc/dbcmodel.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,10 +28,16 @@ YACC=@YACC@
 #	
 # What to build and install
 #
-lib_LTLIBRARIES = libcandbc.la libcanasc.la libcanmdf.la libcanvsb.la \
+lib_LTLIBRARIES = libcandbc.la libcanasc.la libcanvsb.la \
 	          libcanclg.la libcanblf.la
+if MATLAB
+lib_LTLIBRARIES += libcanmdf.la
+endif
 
-bin_PROGRAMS	= dbccopy dbcls cantomat mdftomat matdump
+bin_PROGRAMS	= dbccopy dbcls
+if MATLAB
+bin_PROGRAMS	+= cantomat mdftomat matdump
+endif
 
 #
 # dbcls

--- a/README
+++ b/README
@@ -17,8 +17,16 @@ Some tools are available for testing of converters:
 * matdump displays the content of a MAT file as ASCII text
 * dbccopy copies a DBC file
 
-The tools 'asctomat' and 'mdftomat' require the package matio, which
-needs to be compiled and installed first (see instructions below).
+The tools 'asctomat' and 'mdftomat' require the package matio,
+which in turn requires the package hdf5. Support for these
+tools is optional; either disable them with '--disable-matlab'
+configure option or make sure hdf5 and matio dependencies are
+installed first (see instructions below).
+
+Since hdf5 is intended only for native builds,
+it is recommended to disable the optional tools on cross-compile
+builds of cantools in order to avoid this dependency
+https://support.hdfgroup.org/HDF5/faq/compile.html#cross
 
 Shared libraries for parsing and accessing these files are also
 provided:
@@ -78,7 +86,7 @@ make install
 Compilation of cantools on Windows Subsystem for Linux (WSL)
 ====================
 sudo apt-get install gcc libz-dev libmatio-dev pkg-config flex bison check libglib2.0 subversion automake
-svn checkout https://svn.code.sf.net/p/cantools/code/trunk cantools-code
+git clone https://github.com/aheit/cantools cantools-code
 cd cantools-code
 ./configure
 make

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,12 @@ dnl common library version
 version_info='0:24:0'
 AC_SUBST(version_info)
 
+# custom options
+
+AC_ARG_ENABLE([matlab],
+    AS_HELP_STRING([--disable-matlab], [Disable matlab MAT file support]))
+AM_CONDITIONAL([MATLAB], [test "x$enable_matlab" != "xno"])
+
 # Checks for programs.
  	
 # Turn off shared libraries during beta-testing, since they
@@ -140,7 +146,10 @@ AC_DEFUN([AX_C_ARITHMETIC_RSHIFT], [
 AX_C_ARITHMETIC_RSHIFT
 
 # Checks for libraries
-AC_CHECK_LIB([hdf5], [H5Fcreate], AC_SUBST([HDF5_LIB], [-lhdf5]), ,-lz)
+
+AS_IF([test "x$enable_matlab" != "xno"], [
+    AC_CHECK_LIB([hdf5], [H5Fcreate], AC_SUBST([HDF5_LIB], [-lhdf5]), ,-lz)
+])
 AC_CHECK_LIB([m], [floor], AC_SUBST([Z_LIB], [-lz]))
 AC_CHECK_LIB([z], [deflate])
 
@@ -164,7 +173,9 @@ fi
 #
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.0])
 PKG_CHECK_MODULES([GLIB],  [glib-2.0 >= 2.0])
-PKG_CHECK_MODULES([MATIO], [matio >= 1.5])
+AS_IF([test "x$enable_matlab" != "xno"], [
+    PKG_CHECK_MODULES([MATIO], [matio >= 1.5])
+])
 PKG_CHECK_MODULES([ZLIB],  [zlib >= 1.2])
 #PKG_CHECK_MODULES([HDF5], [hdf5 >= 1.8])
  

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 AC_PREREQ(2.69)
 AC_INIT(cantools, 0.24, andreas.heitmann@gmail.com)
 AC_CONFIG_SRCDIR([src/libcandbc/parser.y])
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADER(cantools_config.h)
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])
 AC_LIBTOOL_WIN32_DLL

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,6 @@ fi
 # Configure check for unit testing
 #
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.0])
-PKG_CHECK_MODULES([GLIB],  [glib-2.0 >= 2.0])
 AS_IF([test "x$enable_matlab" != "xno"], [
     PKG_CHECK_MODULES([MATIO], [matio >= 1.5])
 ])

--- a/malloc.c
+++ b/malloc.c
@@ -18,9 +18,7 @@
 
 /* written by Jim Meyering and Bruno Haible */
 
-#if HAVE_CONFIG_H
-# include <config.h>
-#endif
+#include <cantools_config.h>
 
 /* Only the AC_FUNC_MALLOC macro defines 'malloc' already in config.h.  */
 #ifdef malloc

--- a/src/cantomat/busassignment.c
+++ b/src/cantomat/busassignment.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/cantomat/busassignment.h
+++ b/src/cantomat/busassignment.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "messagehash.h"
 

--- a/src/cantomat/cantomat.c
+++ b/src/cantomat/cantomat.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/cantomat/matwrite.c
+++ b/src/cantomat/matwrite.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdlib.h>
 

--- a/src/cantomat/matwrite.h
+++ b/src/cantomat/matwrite.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "measurement.h"

--- a/src/cantomat/measurement.c
+++ b/src/cantomat/measurement.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/cantomat/measurement.h
+++ b/src/cantomat/measurement.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 

--- a/src/cantomat/messagedecoder.c
+++ b/src/cantomat/messagedecoder.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "dbcmodel.h"
 #include "messagedecoder.h"

--- a/src/cantomat/messagehash.c
+++ b/src/cantomat/messagehash.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "dbcmodel.h"

--- a/src/cantomat/messagehash.h
+++ b/src/cantomat/messagehash.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "dbcmodel.h"

--- a/src/cantomat/signalformat.c
+++ b/src/cantomat/signalformat.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/cantomat/signalformat.h
+++ b/src/cantomat/signalformat.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 typedef enum {
   signalFormat_Name     = 1<<1,

--- a/src/dbccopy/dbccopy.c
+++ b/src/dbccopy/dbccopy.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "dbcreader.h"

--- a/src/dbcls/dbcls.c
+++ b/src/dbcls/dbcls.c
@@ -24,9 +24,7 @@
  * dbcls -d dbcfile -s  > signals.txt
  */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanasc/ascreader.c
+++ b/src/libcanasc/ascreader.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanasc/ascreader.h
+++ b/src/libcanasc/ascreader.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "dbctypes.h"

--- a/src/libcanblf/blfapi.c
+++ b/src/libcanblf/blfapi.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/libcanblf/blfapi.h
+++ b/src/libcanblf/blfapi.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanblf/blfparser.c
+++ b/src/libcanblf/blfparser.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanblf/blfparser.h
+++ b/src/libcanblf/blfparser.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanblf/blfreader.c
+++ b/src/libcanblf/blfreader.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanblf/blfreader.h
+++ b/src/libcanblf/blfreader.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanblf/blfstream.c
+++ b/src/libcanblf/blfstream.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/libcanblf/blfstream.h
+++ b/src/libcanblf/blfstream.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanclg/clgreader.c
+++ b/src/libcanclg/clgreader.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanclg/clgreader.h
+++ b/src/libcanclg/clgreader.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcandbc/dbcmodel.c
+++ b/src/libcandbc/dbcmodel.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcandbc/dbcreader.c
+++ b/src/libcandbc/dbcreader.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcandbc/dbctypes.h
+++ b/src/libcandbc/dbctypes.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcandbc/lexer.c
+++ b/src/libcandbc/lexer.c
@@ -649,9 +649,7 @@ char *yytext;
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 #line 18 "src/libcandbc/lexer.l"
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcandbc/lexer.l
+++ b/src/libcandbc/lexer.l
@@ -16,9 +16,7 @@
 
 %{
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanmdf/mdfcg.c
+++ b/src/libcanmdf/mdfcg.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <assert.h>

--- a/src/libcanmdf/mdfcg.h
+++ b/src/libcanmdf/mdfcg.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "mdfmodel.h"
 #include "mdffilter.h"

--- a/src/libcanmdf/mdfcn.c
+++ b/src/libcanmdf/mdfcn.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <matio.h>
 
 #include "mdfcn.h"
 #include "mdfsg.h"

--- a/src/libcanmdf/mdfcn.c
+++ b/src/libcanmdf/mdfcn.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libcanmdf/mdfcn.h
+++ b/src/libcanmdf/mdfcn.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "mdfmodel.h"
 #include "mdffilter.h"

--- a/src/libcanmdf/mdfdg.c
+++ b/src/libcanmdf/mdfdg.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include "mdfmodel.h"

--- a/src/libcanmdf/mdfdg.h
+++ b/src/libcanmdf/mdfdg.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "mdfmodel.h"
 

--- a/src/libcanmdf/mdffile.c
+++ b/src/libcanmdf/mdffile.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/libcanmdf/mdffilter.c
+++ b/src/libcanmdf/mdffilter.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <limits.h>

--- a/src/libcanmdf/mdffilter.h
+++ b/src/libcanmdf/mdffilter.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include "mdfmodel.h"
 #include "mdftypes.h"

--- a/src/libcanmdf/mdfmodel.c
+++ b/src/libcanmdf/mdfmodel.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <string.h>
 #include "mdfmodel.h"

--- a/src/libcanmdf/mdfsg.c
+++ b/src/libcanmdf/mdfsg.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <assert.h>

--- a/src/libcanmdf/mdfsg.h
+++ b/src/libcanmdf/mdfsg.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanmdf/mdfswap.h
+++ b/src/libcanmdf/mdfswap.h
@@ -32,9 +32,7 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA
    02110-1301, USA. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanmdf/mdftypes.h
+++ b/src/libcanmdf/mdftypes.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanvsb/vsbreader.c
+++ b/src/libcanvsb/vsbreader.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/libcanvsb/vsbreader.h
+++ b/src/libcanvsb/vsbreader.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>

--- a/src/matdump/matdump.c
+++ b/src/matdump/matdump.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stddef.h>
 #include <stdio.h>

--- a/src/matdump/matdump.h
+++ b/src/matdump/matdump.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <matio.h>
 

--- a/src/mdftomat/mdftomat.c
+++ b/src/mdftomat/mdftomat.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stddef.h>
 #include <stdio.h>

--- a/src/mdftomat/mdftomat.h
+++ b/src/mdftomat/mdftomat.h
@@ -17,9 +17,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <matio.h>
 

--- a/strndup.c
+++ b/strndup.c
@@ -16,9 +16,7 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include "cantools_config.h"
 
 #include <stdio.h>
 #include <sys/types.h>

--- a/strnlen.c
+++ b/strnlen.c
@@ -14,9 +14,7 @@
    along with this program; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
-#ifdef HAVE_CONFIG_H
-# include <conf ig.h>
-#endif
+#include <cantools_config.h>
 
 #if !defined (HAVE_STRNLEN)
 

--- a/strtod.c
+++ b/strtod.c
@@ -14,9 +14,7 @@
    along with this program; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
-#if HAVE_CONFIG_H
-# include <config.h>
-#endif
+#include <cantools_config.h>
 
 #ifndef HAVE_STRTOD
 

--- a/tests/check_mdf_signal_convert.c
+++ b/tests/check_mdf_signal_convert.c
@@ -14,9 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include "cantools_config.h"
 
 /* Check unit test tool header */
 #include <check.h>

--- a/tests/check_mdf_signal_convert.c
+++ b/tests/check_mdf_signal_convert.c
@@ -30,11 +30,6 @@ enum {
   BO_LITTLE=0,
   BO_BIG=1
 } byte_order_e;
-	
-int main(void)
-{
-    return 0;
-}
 
 /* test, if payload is extracted correctly */
 
@@ -158,3 +153,32 @@ START_TEST(check_mdf_signal_convert)
   }
 }
 END_TEST
+
+Suite * test_suite(void)
+{
+  Suite *s;
+  TCase *tc_core;
+
+  s = suite_create("cantools");
+  tc_core = tcase_create("Core");
+  tcase_add_test(tc_core, check_mdf_signal_convert);
+  suite_add_tcase(s, tc_core);
+
+  return s;
+}
+
+int main(void)
+{
+  int number_failed;
+  Suite *s;
+  SRunner *sr;
+
+  s = test_suite();
+  sr = srunner_create(s);
+
+  srunner_run_all(sr, CK_NORMAL);
+  number_failed = srunner_ntests_failed(sr);
+  srunner_free(sr);
+  return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+


### PR DESCRIPTION
The biggest barrier to cross-compile support was cantool's mandatory dependency on hdf5 library, which is documented by its developers as not supporting cross-compile builds. cantools is still useful without the matlab utilities, so '--disable-matlab' configure switch allows incorporating the remaining parts of cantools into an image generated by OpenEmbedded/yocto build system.

Also got rid of a dependency on glib, which seems to be completely unused at this point. glib is available for cross-compile builds but embedded targets tend to have much more limited space than a desktop so useless dependencies can be more of a burden.

In order to have a little more confidence that things are still running properly with or without '--disable-matlab', fixed the test case so that it really runs the test function on 'make check' (previously it was just a compile check, probably unintentionally because the libcheck tutorial is confusing in that regard).